### PR TITLE
Make a single voluntary exit verify entity

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
@@ -22,6 +22,7 @@ import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier.InvalidSignatureException;
 import tech.pegasys.teku.core.BlockProcessorUtil;
+import tech.pegasys.teku.core.BlockVoluntaryExitValidator;
 import tech.pegasys.teku.core.StateTransitionException;
 import tech.pegasys.teku.core.exceptions.BlockProcessingException;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
@@ -80,8 +81,8 @@ public class SimpleBlockValidator implements BlockValidator {
         BlockProcessorUtil.verify_randao(preState, blockMessage, signatureVerifier);
         BlockProcessorUtil.verify_proposer_slashings(
             preState, blockBody.getProposer_slashings(), signatureVerifier);
-        BlockProcessorUtil.verify_voluntary_exits(
-            preState, blockBody.getVoluntary_exits(), signatureVerifier);
+        new BlockVoluntaryExitValidator(signatureVerifier)
+            .validateBlockExitsAndThrow(preState, blockBody.getVoluntary_exits().asList());
       }
       return SafeFuture.completedFuture(new BlockValidationResult(true));
     } catch (BlockProcessingException | InvalidSignatureException e) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/VoluntaryExitValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/VoluntaryExitValidator.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.networking.eth2.gossip.topics.validation;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.core.BlockProcessorUtil.verify_voluntary_exits;
 import static tech.pegasys.teku.networking.eth2.gossip.topics.validation.ValidationResult.INVALID;
 import static tech.pegasys.teku.networking.eth2.gossip.topics.validation.ValidationResult.VALID;
 import static tech.pegasys.teku.util.config.Constants.VALID_VALIDATOR_SET_SIZE;
@@ -24,11 +23,9 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.core.BlockVoluntaryExitValidator;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.collections.ConcurrentLimitedSet;
 import tech.pegasys.teku.util.collections.LimitStrategy;
@@ -79,8 +76,7 @@ public class VoluntaryExitValidator {
           invalidReason.isEmpty(),
           "process_voluntary_exit: %s",
           invalidReason.map(BlockVoluntaryExitValidator.ExitInvalidReason::describe).orElse(""));
-      verify_voluntary_exits(state, SSZList.singleton(exit), BLSSignatureVerifier.SIMPLE);
-    } catch (IllegalArgumentException | BLSSignatureVerifier.InvalidSignatureException e) {
+    } catch (IllegalArgumentException e) {
       LOG.trace("VoluntaryExitValidator: Exit fails process voluntary exit conditions.", e);
       return false;
     }


### PR DESCRIPTION
## PR Description

Here I tried to merge all voluntary exits verification stuff (both BLS and data validity) to a single `BlockVoluntaryExitValidator` class
Also added a method for independent validation of block exists: additionally the uniqueness of validators should be checked in this case 

I saw the original PR was already merged, so left it here for may be changing later 